### PR TITLE
Mangle stacktrace to exclude mocha and browserify frames

### DIFF
--- a/lib/phantomic.js
+++ b/lib/phantomic.js
@@ -4,9 +4,12 @@ var through   = require('through');
 var convert   = require('convert-source-map');
 var sourceMap = require('source-map');
 var spawn     = require('child_process').spawn;
+var path      = require('path');
 
 
-var RE = /http\:\/\/localhost\:[0-9]+\/js\/bundle\:([0-9]+)/g;
+var cwd = process.cwd();
+var RE = /http\:\/\/localhost\:[0-9]+\/js\/bundle\:([0-9]+)/;
+var IGNORE_RE = /(node_modules\/browser\-pack\/_prelude\.js)|(node_modules\/mocha\/mocha\.js)/;
 
 
 function pipe(stdin, phin, phout, stdout) {
@@ -31,17 +34,7 @@ function pipe(stdin, phin, phout, stdout) {
           buf += data.toString();
           var p = buf.lastIndexOf('\n');
           if (p !== -1) {
-            var str = buf.substring(0, p + 1).replace(RE, function (m, nr) {
-              /*jslint unparam: true*/
-              if (nr < 1) {
-                return '?';
-              }
-              var mapped = mapper.originalPositionFor({
-                line   : nr,
-                column : 0
-              });
-              return mapped.source + ':' + mapped.line;
-            });
+            var str = mapStacktrace(mapper, buf, p);
             stdout.queue(str);
             buf = buf.substring(p + 1);
           }
@@ -59,6 +52,34 @@ function pipe(stdin, phin, phout, stdout) {
   });
 }
 
+function mapStacktrace(mapper, str, p) {
+  return str
+    .split('\n')
+    .map(function(line) {
+      var ignore = false;
+      line = line.replace(RE, function (m, nr) {
+        /*jslint unparam: true*/
+        if (nr < 1) {
+          return '?';
+        }
+        var mapped = mapper.originalPositionFor({
+          line   : nr,
+          column : 0
+        });
+        if (IGNORE_RE.exec(mapped.source)) {
+          ignore = true;
+        }
+        var relativeSource = path.relative(cwd, mapped.source);
+        var source = /^\.\./.exec(relativeSource) ?
+          mapped.source :
+          relativeSource;
+        return source + ':' + mapped.line;
+      });
+      return ignore ? undefined : line;
+    })
+    .filter(function(line) { return line !== undefined; })
+    .join('\n');
+}
 
 module.exports = function (input, cb) {
   var phantomjs = spawn('phantomjs', [__dirname + '/runner.js'], {


### PR DESCRIPTION
Mangle stacktraces to exclude mocha and browserify frames, also make source filenames relative to cwd. This enables nice stacktraces.

To be honest, I don't think this is the right place for this code but it makes everything so nice so I'd just open PR and let the discussion happen. Probably we can include a generic mechanism for excluding stack frames from stack traces in phantomic and let mochify orchestrate that.
