### PR TITLE
Prevent the page from navigating after the initial page is loaded.

### DIFF
--- a/lib/runner.js
+++ b/lib/runner.js
@@ -81,3 +81,4 @@ page.onError = function (msg, trace) {
 };
 
 page.open(url);
+page.navigationLocked = true;


### PR DESCRIPTION
This is a fix for bug that I experienced in/through mochify. One of my tests was asserting if a `click` event on an `<a>` element was working as intended. I used DOM Events to simulate the click on the link but forgot to set the cancelable attribute so the `preventDefault` in the event listener had no affect and caused the PhantomJS page to navigate to the clicked URL. This again, caused the test runner to running the rest of the tests as the page was gone which results in an forever spinning test suite.

By preventing the page navigation **after** the initial open call, it will now correctly cause an error in mochify and close kill the test suite.