### PR TITLE
Add the missing SSL Error Test

### DIFF
--- a/test/ignore-ssl-errors.js
+++ b/test/ignore-ssl-errors.js
@@ -1,0 +1,7 @@
+var xhr = new XMLHttpRequest();
+// this website should have an intentional bad cert
+xhr.open('GET', 'https://revoked.grc.com', false);
+xhr.onload = function() {
+  console.log('--ignore-ssl-errors=true');
+};
+xhr.send();


### PR DESCRIPTION
I know this is dependent a public website with an intentional SSL error. However, the only other alternative would be spinning up a server (within the test) and checking in certificates for the server, and at that rate aren't we basically testing PhantomJS?