### PR TITLE
Set phantomJS TimeZone to environment TimeZone

### DIFF
--- a/lib/phantomic.js
+++ b/lib/phantomic.js
@@ -61,13 +61,15 @@ function launchPhantom(output, options, callback) {
       });
     }
   };
+  var env = {
+    PATH: process.env.PATH,
+    PHANTOMIC_PORT: options.port,
+    PHANTOMIC_DEBUG: options.debug ? '1' : '',
+    PHANTOMIC_BROUT: options.brout ? '1' : ''
+  };
+  if (process.env.TZ) env.TZ = process.env.TZ;
   var phantomjs = spawn(options.phantomjs || 'phantomjs', args, {
-    env: {
-      PATH: process.env.PATH,
-      PHANTOMIC_PORT: options.port,
-      PHANTOMIC_DEBUG: options.debug ? '1' : '',
-      PHANTOMIC_BROUT: options.brout ? '1' : ''
-    }
+    env: env
   });
   phantomjs.stdout.pipe(output, { end: false });
   phantomjs.stderr.on('data', function (data) {

--- a/test/suite.sh
+++ b/test/suite.sh
@@ -53,4 +53,9 @@ assert "node bin/cmd.js --web-security false --ignore-ssl-errors true < test/ign
 
 assert "node bin/cmd.js < test/navigation.js" "no navigation"
 
+export TZ='Europe/Berlin'
+assert "node bin/cmd.js < test/timezone.js" "-60"
+export TZ='America/New_York'
+assert "node bin/cmd.js < test/timezone.js" "300"
+
 assert_end

--- a/test/timezone.js
+++ b/test/timezone.js
@@ -1,0 +1,1 @@
+console.log(new Date().getTimezoneOffset());


### PR DESCRIPTION
currently phantomic is not able to run with different timezones.
My normal timezone in the example is `Europe/Berlin (-60)`

Here is an example if you run a simple test with mochify and try to set the time zone of phantomjs:
the shell commands:

    export TZ=America/New_York
    npm run test

`simple-test.js`:

    describe('timezoneOffset should equal New-York (300)', () => {
    expect(new Date().getTimezoneOffset()).to.be.eql(300);
    }

the output:
`# phantomjs:
AssertionError: expected -60 to deeply equal 300`

After adding my commited code the AssertionError no longer occurs, since the value of phantoms' `TZ`is set to the `process.env.TZ`

Last but not least, if there is no TZ environment variable, phantomjs will just use the system timezone
